### PR TITLE
Fix program counter bounds check in output_add_values

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -58,7 +58,7 @@ void output_add_values(output *output, const char *values, size_t size)
     if (output->pc < output->start) {
         output->start = output->pc;
     }
-    if (output->pc + size >= 0x10000) {
+    if (output->pc + size > 0x10000) {
         if (output->pc_overflow_handler.callback) {
             output->pc_overflow_handler.callback(output, output->pc_overflow_handler.data);
             return;


### PR DESCRIPTION
Suggested fix for https://github.com/informedcitizenry/tiny6502/issues/1. Please refer to the issue for more details.

For the example programs I provided in the issue, I get the following output with this change:

```
% ./build/tiny6502 test1.asm
tiny6502 cross-assembler 0.2 (c) 2022 informedcitizenry
tiny6502 comes with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to redistribute it under certain conditions as defined in the LICENSE.
---------------------------------
1 passes

Start address: $FFFE
End address:   $10000
Bytes written: 2
```

```
% ./build/tiny6502 test2.asm
tiny6502 cross-assembler 0.2 (c) 2022 informedcitizenry
tiny6502 comes with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to redistribute it under certain conditions as defined in the LICENSE.
---------------------------------
1 passes

Start address: $FFFF
End address:   $10000
Bytes written: 1
```